### PR TITLE
Fix the bugs: 1.Log report descriptor truncated; 2.Scan interrupted for access denial.

### DIFF
--- a/rd_reader.py
+++ b/rd_reader.py
@@ -101,7 +101,7 @@ class HIDReportDescriptorReader:
             self.report_descriptor = None
             for d in range(n_descriptors):
                 desc_type = desc_bytes[6 + (d*3)]
-                desc_length = desc_bytes[7 + (d*3)] | (desc_bytes[8 + (d*3)])
+                desc_length = desc_bytes[7 + (d*3)] | ((desc_bytes[8 + (d*3)]) << 8)
                 if desc_type == _USB_HID_CLASS_REPORT_DESCRIPTOR_TYPE:
                     self.report_descriptor = device.ctrl_transfer(_USB_CLASS_bmRequestType_GET_DESCRIPTOR,
                                 _USB_CLASS_bRequest_GET_DESCRIPTOR,


### PR DESCRIPTION
Bug 1. Log report descriptor truncated
The length was wrongly calculated.

Bug2. usb.core.find(find_all=True, custom_match = is_hid) sometimes interrupted by access denial

Here's the stdout of an example of long report descriptor of a kind of headset with my fix to Bug 1.

Interface Number: 3
Report Descriptor:
Usage Page(0xb)
Usage(0x5)
Collection(0x1)
  Report ID(0x2)
  Usage Page(0xb)
  Logical Minimum(0x0)
  Logical Maximum(0x1)
  Usage(0x20)
  Usage(0x97)
  Report Size(0x1)
  Report Count(0x2)
  Input(0x23)
  Usage(0x2f)
  Usage(0x21)
  Usage(0x24)
  Usage(0x50)
  Report Size(0x1)
  Report Count(0x4)
  Input(0x6)
  Usage(0x7)
  Usage Page(0x9)
  Report Size(0x1)
  Report Count(0x1)
  Input(0x2)
  Usage Page(0xb)
  Usage(0x6)
  Collection(0x2)
    Usage Minimum(0xb0)
    Usage Maximum(0xbb)
    Logical Minimum(0x0)
    Logical Maximum(0xb)
    Report Size(0x4)
    Report Count(0x1)
    Input(0x0)
  End Collection
  Report Size(0x1)
  Report Count(0x5)
  Input(0x1)
  Usage Page(0x8)
  Logical Minimum(0x0)
  Logical Maximum(0x1)
  Usage(0x17)
  Usage(0x9)
  Usage(0x18)
  Usage(0x20)
  Usage(0x21)
  Report Size(0x1)
  Report Count(0x5)
  Output(0x22)
  Usage Page(0xb)
  Logical Minimum(0x0)
  Logical Maximum(0x1)
  Usage(0x9e)
  Report Size(0x1)
  Report Count(0x1)
  Output(0x22)
  Report Size(0x1)
  Report Count(0xa)
  Output(0x1)
End Collection
Usage Page(0xff00)
Usage(0x5)
Collection(0x1)
  Report ID(0x4)
  Usage Page(0xff30)
  Logical Minimum(0x0)
  Logical Maximum(0x1)
  Usage(0xffff)
  Report Size(0x1)
  Report Count(0x1)
  Feature(0x23)
  Report Size(0x1)
  Report Count(0x7)
  Feature(0x1)
  Usage(0x20)
  Usage(0x97)
  Report Size(0x1)
  Report Count(0x2)
  Input(0x23)
  Usage(0x2f)
  Usage(0x21)
  Usage(0x24)
  Usage(0xfffd)
  Usage(0x50)
  Report Size(0x1)
  Report Count(0x5)
  Input(0x7)
  Usage(0x6)
  Collection(0x2)
    Usage Minimum(0xb0)
    Usage Maximum(0xbb)
    Logical Minimum(0x0)
    Logical Maximum(0xc)
    Report Size(0x4)
    Report Count(0x1)
    Input(0x0)
  End Collection
  Report Size(0x1)
  Report Count(0x5)
  Input(0x1)
  Usage Page(0xff40)
  Logical Minimum(0x0)
  Logical Maximum(0x1)
  Usage(0x17)
  Usage(0x9)
  Usage(0x18)
  Usage(0x20)
  Usage(0x21)
  Report Size(0x1)
  Report Count(0x5)
  Output(0x22)
  Usage Page(0xff30)
  Logical Minimum(0x0)
  Logical Maximum(0x1)
  Usage(0x9e)
  Report Size(0x1)
  Report Count(0x1)
  Output(0x22)
  Report Size(0x1)
  Report Count(0xa)
  Output(0x1)
  Report ID(0x5)
  Usage Page(0xff00)
  Usage(0x1)
  Logical Minimum(0x0)
  Logical Maximum(0xff)
  Report Size(0x8)
  Report Count(0x20)
  Output(0x102)
  Usage(0x1)
  Logical Minimum(0x0)
  Logical Maximum(0xff)
  Report Size(0x8)
  Report Count(0x20)
  Input(0x102)
End Collection
Usage Page(0xc)
Usage(0x1)
Collection(0x1)
  Report ID(0x1)
  Logical Minimum(0x0)
  Logical Maximum(0x1)
  Usage(0xea)
  Usage(0xe9)
  Report Size(0x1)
  Report Count(0x2)
  Input(0x2)
  Report Size(0x1)
  Report Count(0xe)
  Input(0x1)
End Collection